### PR TITLE
Change placeholders for direction, edit on click for search 

### DIFF
--- a/src/components/Directions.js
+++ b/src/components/Directions.js
@@ -53,6 +53,7 @@ class Directions extends Component {
                     writeSearch={(value) => this.props.writeSearchFrom(value)}
                     resultsClass={'mt48 ' + this.styles.results}
                     inputClass={this.styles.input}
+                    inputPlaceholder='Choose starting point...'
                   />
                 }
                 <CloseButton
@@ -73,6 +74,7 @@ class Directions extends Component {
                     writeSearch={(value) => this.props.writeSearchTo(value)}
                     resultsClass={'mt6 ' + this.styles.results}
                     inputClass={this.styles.input}
+                    inputPlaceholder='Choose destination...'
                   />
                 }
                 <CloseButton
@@ -106,8 +108,8 @@ class Directions extends Component {
   setDirectionsLocation(kind) {
     return (location) => {
       this.props.setDirectionsLocation(kind, location);
-      if (kind === 'to') this.props.writeSearchTo('');
-      if (kind === 'from') this.props.writeSearchFrom('');
+      if (kind === 'to') this.props.writeSearchTo(location.place_name);
+      if (kind === 'from') this.props.writeSearchFrom(location.place_name);
       this.props.triggerMapUpdate('repan');
     };
   }

--- a/src/components/Directions.js
+++ b/src/components/Directions.js
@@ -45,42 +45,59 @@ class Directions extends Component {
                 {
                   this.props.directionsFrom
                   ? <div className={this.styles.placeName}>
-                    <PlaceName location={this.props.directionsFrom} colors='light'/>
+                    <PlaceName
+                      location={this.props.directionsFrom}
+                      colors='light'
+                      onClick={() => {
+                        this.props.writeSearchFrom(this.props.directionsFrom.place_name);
+                        this.props.setDirectionsLocation('from', null);
+                        this.props.setRoute(null);
+                        this.props.setStateValue('routeStatus', 'idle');
+                      }}
+                    />
                   </div>
                   : <Geocoder
                     onSelect={this.setDirectionsLocation('from')}
                     searchString={this.props.directionsFromString}
-                    writeSearch={(value) => this.props.writeSearchFrom(value)}
+                    writeSearch={(value) => {
+                      this.props.writeSearchFrom(value);
+                      this.props.triggerMapUpdate();
+                    }}
                     resultsClass={'mt48 ' + this.styles.results}
                     inputClass={this.styles.input}
                     inputPlaceholder='Choose starting point...'
+                    focusOnMount={true}
                   />
                 }
-                <CloseButton
-                  onClick={() => this.resetSearch('from')}
-                  color='color-lighten50'
-                />
               </div>
 
               <div className={this.styles.row}>
                 {
                   this.props.directionsTo
                   ? <div className={this.styles.placeName}>
-                    <PlaceName location={this.props.directionsTo} colors='light'/>
+                    <PlaceName
+                      location={this.props.directionsTo}
+                      colors='light'
+                      onClick={() => {
+                        this.props.writeSearchTo(this.props.directionsTo.place_name);
+                        this.props.setDirectionsLocation('to', null);
+                        this.props.setRoute(null);
+                        this.props.setStateValue('routeStatus', 'idle');
+                      }}
+                    />
                   </div>
                   : <Geocoder
                     onSelect={this.setDirectionsLocation('to')}
                     searchString={this.props.directionsToString}
-                    writeSearch={(value) => this.props.writeSearchTo(value)}
+                    writeSearch={(value) => {
+                      this.props.writeSearchTo(value);
+                      this.props.triggerMapUpdate();
+                    }}
                     resultsClass={'mt6 ' + this.styles.results}
                     inputClass={this.styles.input}
                     inputPlaceholder='Choose destination...'
                   />
                 }
-                <CloseButton
-                  onClick={() => this.resetSearch('to')}
-                  color='color-lighten50'
-                />
               </div>
 
             </div>
@@ -142,6 +159,7 @@ class Directions extends Component {
   }
 
   showUserLocation() {
+    console.log(this.props.directionsFromString)
     return (
       (
         (!this.props.directionsFrom && !this.props.directionsTo)

--- a/src/components/Geocoder.js
+++ b/src/components/Geocoder.js
@@ -125,12 +125,12 @@ var Geocoder = React.createClass({
     this.props.onSelect(place);
     this.setState({focus: listLocation});
     // focus on the input after click to maintain key traversal
-    ReactDOM.findDOMNode(this.refs.input).focus(); // eslint-disable-line
+    this.input.focus();
     return false;
   },
   render() {
     var input = <input
-      ref='input'
+      ref={(input) => { this.input = input; }}
       className={this.props.inputClass}
       onInput={this.onInput}
       onKeyDown={this.onKeyDown}

--- a/src/components/Geocoder.js
+++ b/src/components/Geocoder.js
@@ -1,7 +1,6 @@
 // forked from https://github.com/mapbox/react-geocoder
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {connect} from 'react-redux';
 import PlaceName from './PlaceName';
 import xhr from 'xhr';
@@ -19,7 +18,8 @@ var Geocoder = React.createClass({
       source: 'mapbox.places',
       bbox: '',
       types: '',
-      onSuggest: function () {}
+      onSuggest: function () {},
+      focusOnMount: true
     };
   },
   getInitialState() {
@@ -163,6 +163,9 @@ var Geocoder = React.createClass({
         {this.props.inputPosition === 'bottom' && input}
       </div>
     );
+  },
+  componentDidMount() {
+    if (this.props.focusOnMount) this.input.focus();
   }
 });
 

--- a/src/components/PlaceName.js
+++ b/src/components/PlaceName.js
@@ -17,7 +17,7 @@ class PlaceName extends Component {
     }
 
     return (
-      <div className='txt-truncate w-full'>
+      <div className='txt-truncate w-full' onClick={() => this.props.onClick()}>
         {
           main === '__loading'
           ? <div className={'loading loading--s ' + (this.props.colors === 'light' ? 'loading--dark' : '')}></div>
@@ -32,7 +32,11 @@ class PlaceName extends Component {
 PlaceName.propTypes = {
   colors: React.PropTypes.string,
   location: React.PropTypes.object,
+  onClick: React.PropTypes.func
 };
 
+PlaceName.defaultProps = {
+  onClick: function () {}
+};
 
 export default PlaceName;

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -8,19 +8,6 @@ import directionsIcon from '../assets/directions.svg';
 import {triggerMapUpdate, setDirectionsLocation, getPlaceInfo, setStateValue} from '../actions/index';
 
 class Search extends Component {
-  closeSearch() {
-    this.props.writeSearch('');
-    this.props.setSearchLocation(null);
-    this.props.setPlaceInfo(null);
-    this.props.triggerMapUpdate();
-  }
-
-  clickDirections() {
-    this.props.setMode('directions');
-    this.props.writeSearch('');
-    this.props.setDirectionsLocation('to', this.props.searchLocation);
-  }
-
   render() {
     return (
       <div className={this.styles.main}>
@@ -32,13 +19,23 @@ class Search extends Component {
           ? <Geocoder
             onSelect={(data) => this.onSelect(data)}
             searchString={this.props.searchString}
-            writeSearch={(value) => this.props.writeSearch(value)}
+            writeSearch={(value) => {
+              this.props.triggerMapUpdate();
+              this.props.writeSearch(value);
+            }}
             resultsClass={this.styles.results}
             inputClass={this.styles.input}
           />
           : <div className={this.styles.input + ' flex-parent flex-parent--center-cross flex-parent--center-main'}>
             <div className='w-full w420-mm pr42 txt-truncate'>
-              <PlaceName location={this.props.searchLocation}/>
+              <PlaceName
+                location={this.props.searchLocation}
+                onClick={() => {
+                  this.props.writeSearch(this.props.searchLocation.place_name);
+                  this.props.setSearchLocation(null);
+                  this.props.setPlaceInfo(null);
+                }}
+              />
             </div>
             <div
               className={'mr30 cursor-pointer right ' + this.styles.icon}
@@ -63,9 +60,23 @@ class Search extends Component {
   }
 
   onSelect(data) {
+    this.props.writeSearch(data.place_name);
     this.props.setSearchLocation(data);
     this.props.triggerMapUpdate('repan');
     if (data.properties.wikidata) this.props.getPlaceInfo(data.properties.wikidata);
+  }
+
+  closeSearch() {
+    this.props.writeSearch('');
+    this.props.setSearchLocation(null);
+    this.props.setPlaceInfo(null);
+    this.props.triggerMapUpdate();
+  }
+
+  clickDirections() {
+    this.props.setMode('directions');
+    this.props.writeSearch(this.props.searchLocation.place_name);
+    this.props.setDirectionsLocation('to', this.props.searchLocation);
   }
 
   get styles() {

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -25,6 +25,7 @@ class Search extends Component {
             }}
             resultsClass={this.styles.results}
             inputClass={this.styles.input}
+            focusOnMount={true}
           />
           : <div className={this.styles.input + ' flex-parent flex-parent--center-cross flex-parent--center-main'}>
             <div className='w-full w420-mm pr42 txt-truncate'>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -46,7 +46,7 @@ const reducer = (state = defaultState, action) => {
   case 'SET_USER_LOCATION':
     return Object.assign({}, state, {
       userLocation: {
-        'place_name': 'My location',
+        'place_name': 'My Location',
         center: action.coordinates,
         geometry: {
           type: 'Point',


### PR DESCRIPTION
- from/to placeholders in directions mode
- edit on click in search mode.

Click to edit remains to be done on the directions page, and UX could be a bit better (focus on the text field after click). I'll add it to the PR later.

We might be able to get rid of the "close" buttons on the directions page altogether.

cc @sarahmamy fixes #17 and part of #16 