### PR TITLE
Changed the link to generate static images more flexibly

### DIFF
--- a/src/components/StyleSwitch.js
+++ b/src/components/StyleSwitch.js
@@ -29,7 +29,7 @@ class StyleSwitch extends Component {
   }
 
   get imgUrl() {
-    var style = this.props.mapStyle.indexOf('streets') > -1 ? 'mapbox/satellite-v9/' : 'benjamintd/cj0szkyh5009i2slfhsmxhtni/';
+    var style = this.props.mapStyle.indexOf('streets') > -1 ? 'mapbox/satellite-v9/' : 'mapbox/streets-v10/'; // Change these to refer to the styles you are using. Originally was 'benjamintd/cj0szkyh5009i2slfhsmxhtni/'
     var base = 'https://api.mapbox.com/styles/v1/' + style + 'static/';
     var coords = this.props.center.join(',') + ',' + Math.max(0, this.props.zoom - 4);
     var size = '56x100@2x';


### PR DESCRIPTION
Changed a link in src/components/StyleSwitch.js so that rather than try to generate static images based on a specific user's style which requires an api key, it will just use the basic Mapbox Streets style to generate these images with a comment showing an example of a custom style link.